### PR TITLE
Bump aws sdk to 1.11.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :distribution :repo}
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.amazonaws/aws-java-sdk "1.11.0"]
+                 [com.amazonaws/aws-java-sdk "1.11.6"]
                  [com.taoensso/faraday "1.7.1" ; DynamoDB sugar
                   :exclusions [com.amazonaws/aws-java-sdk-dynamodb joda-time]]
                  [fullcontact/full.http "0.10.8"]


### PR DESCRIPTION
@fullcontact/middleware 

This resolves the issue where spaces in file names are not encoded properly, resulting in signature mismatch errors.