### PR TITLE
S3: Allow custom client for listing objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ pom.xml
 pom.xml.asc
 *.jar
 *.class
+*.iml
 /.lein-*
 /.nrepl-port
+.idea/

--- a/src/full/aws/s3.clj
+++ b/src/full/aws/s3.clj
@@ -137,12 +137,14 @@
                :response-parser (comp read-edn string-response-parser)
                :client client))
 
-(defn list-objects> [bucket-name prefix]
+(defn list-objects>
+  [^String bucket-name ^String prefix
+   & {:keys [client] :or {client @client}}]
   (let [req (-> (ListObjectsRequest.)
                 (.withBucketName bucket-name)
                 (.withPrefix prefix))]
     (thread-try
-      (.listObjects @client req))))
+      (.listObjects client req))))
 
 (defn delete-object>
   [^String bucket-name, ^String key


### PR DESCRIPTION
Add option for passing in a custom client to `list-objects>`. Not sure why this one method didn't have this.